### PR TITLE
Simplify HTSGET workflow to basic three-method fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+work/
+.nextflow*
+results/
+reports/
+bin/__pycache__/
+*.pyc
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
 FROM python:3.12-slim
 
-RUN pip install --no-cache-dir htsget==0.1.0a2
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+        htsget==0.1.0a2 \
+        requests

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # nextflow-htsget
-basic seqera pipeline that uses python client to hit htsget endpoint for any sample
+
+Minimal Docker-based Nextflow workflow that fetches GA4GH HTSGET data three ways:
+
+| Method | Tool | What it does |
+| --- | --- | --- |
+| `cli` | `htsget get` | Streams the BAM demo sample with the official client. |
+| `python` | `bin/fetch_htsget.py` | Resolves the discovery document and writes the first data block. |
+| `curl` | `curl` | Saves the raw discovery JSON returned by the endpoint. |
+
+## Samplesheet
+
+Inputs come from `samplesheet.csv` (override with `--samplesheet`). Each row
+needs:
+
+- `id`: identifier used to derive defaults
+- `name`: optional label for logging (defaults to `id`)
+- `filetype`: one of `cli`, `python`, or `curl`
+- `uri`: the HTSGET discovery endpoint to fetch
+- `filename`: file name to emit for that method
+
+The included example points at the GA4GH demo service.
+
+## Run
+
+All processes run inside `docker.io/qclayssen/htsget-demo:latest`. Build and
+push that image if you change the code.
+
+Execute locally or on Seqera Platform:
+
+```bash
+nextflow run main.nf --outdir results
+```
+
+Outputs land in `<outdir>/cli`, `<outdir>/python`, and `<outdir>/curl`.

--- a/bin/fetch_htsget.py
+++ b/bin/fetch_htsget.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Resolve an HTSGET discovery URL and download the first data block."""
+
+import argparse
+from pathlib import Path
+
+import requests
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("uri", help="HTSGET discovery endpoint")
+    parser.add_argument("output", help="Destination file")
+    args = parser.parse_args()
+
+    discovery = args.uri.replace("htsget://", "https://", 1)
+    response = requests.get(discovery, timeout=60)
+    response.raise_for_status()
+    payload = response.json()
+
+    body = payload.get("htsget", payload)
+    urls = body.get("urls") or body.get("accessMethods") or []
+    if not urls:
+        raise SystemExit("No data URLs available")
+
+    first = urls[0]
+    if isinstance(first, dict):
+        data_url = first.get("url") or (first.get("accessUrl") or {}).get("url")
+    else:
+        data_url = first
+    if not data_url:
+        raise SystemExit("Missing download URL")
+
+    target = Path(args.output)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    with requests.get(data_url, stream=True, timeout=120) as handle:
+        handle.raise_for_status()
+        with target.open("wb") as out_handle:
+            for chunk in handle.iter_content(1024 * 1024):
+                if chunk:
+                    out_handle.write(chunk)
+
+
+if __name__ == "__main__":
+    main()

--- a/main.nf
+++ b/main.nf
@@ -1,0 +1,84 @@
+nextflow.enable.dsl=2
+
+params.outdir = params.outdir ?: 'results'
+params.samplesheet = params.samplesheet ?: 'samplesheet.csv'
+
+// Helper that returns the rows for a given method.
+def method_rows(String method) {
+    Channel
+        .fromPath(params.samplesheet)
+        .splitCsv(header: true)
+        .filter { row ->
+            row.filetype?.trim()?.toLowerCase() == method
+        }
+        .map { row ->
+            def name = row.name?.trim() ?: row.id?.trim() ?: method
+            def uri = row.uri?.trim()
+            if (!uri) {
+                log.error "Row for '${name}' (${method}) is missing a uri"
+                System.exit(1)
+            }
+            def filename = row.filename?.trim()
+            if (!filename) {
+                filename = "${name}_${method}"
+            }
+            tuple(name, uri, filename)
+        }
+}
+
+process FETCH_WITH_CLI {
+    tag { sample }
+    publishDir "${params.outdir}/cli", mode: 'copy'
+
+    input:
+        tuple val(sample), val(uri), val(filename)
+
+    output:
+        path filename
+
+    script:
+    """
+    set -euo pipefail
+    htsget get '${uri}' --output '${filename}'
+    """
+}
+
+process FETCH_WITH_PYTHON {
+    tag { sample }
+    publishDir "${params.outdir}/python", mode: 'copy'
+
+    input:
+        tuple val(sample), val(uri), val(filename)
+
+    output:
+        path filename
+
+    script:
+    """
+    set -euo pipefail
+    bin/fetch_htsget.py '${uri}' '${filename}'
+    """
+}
+
+process FETCH_WITH_CURL {
+    tag { sample }
+    publishDir "${params.outdir}/curl", mode: 'copy'
+
+    input:
+        tuple val(sample), val(uri), val(filename)
+
+    output:
+        path filename
+
+    script:
+    """
+    set -euo pipefail
+    curl -sS '${uri}' -o '${filename}'
+    """
+}
+
+workflow {
+    FETCH_WITH_CLI(method_rows('cli'))
+    FETCH_WITH_PYTHON(method_rows('python'))
+    FETCH_WITH_CURL(method_rows('curl'))
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,23 @@
+manifest {
+    name = 'nextflow-htsget'
+    author = 'Seqera Pipelines'
+    description = 'Demonstration pipeline that downloads GA4GH HTSGET data via three methods.'
+}
+
+params {
+    outdir = 'results'
+    samplesheet = 'samplesheet.csv'
+}
+
+docker {
+    enabled = true
+}
+
+process {
+    container = 'docker.io/qclayssen/htsget-demo:latest'
+    executor = 'local'
+}
+
+trace {
+    enabled = true
+}

--- a/samplesheet.csv
+++ b/samplesheet.csv
@@ -1,0 +1,4 @@
+id,name,filetype,uri,filename
+ga4gh_demo,NA12878,cli,https://htsget.ga4gh-demo.org/reads/htsnexus_test_NA12878,reads_cli.bam
+ga4gh_demo,NA12878,python,https://htsget.ga4gh-demo.org/variants/spec-v4.3,variants_python.vcf
+ga4gh_demo,NA12878,curl,https://htsget.ga4gh-demo.org/reads/htsnexus_test_NA12878,reads_discovery.json


### PR DESCRIPTION
This pull request introduces a minimal, Docker-based Nextflow pipeline that demonstrates fetching GA4GH HTSGET data using three different methods: the official CLI, a Python script, and curl. It adds a sample sheet-driven workflow, updates documentation, and configures the environment for reproducible execution.

**Pipeline and Workflow Implementation:**

* Introduced a new Nextflow workflow in `main.nf` that reads from a configurable `samplesheet.csv` and runs three processes (`FETCH_WITH_CLI`, `FETCH_WITH_PYTHON`, `FETCH_WITH_CURL`), each fetching HTSGET data by a different method and publishing outputs to separate directories.
* Added a sample `samplesheet.csv` with example entries for each method, demonstrating expected input format and usage.

**Environment and Configuration:**

* Created a `nextflow.config` file to define pipeline metadata, default parameters, Docker container usage, and process execution settings, ensuring reproducible and containerized runs.
* Updated the `Dockerfile` to install required dependencies (`curl`, `requests`, and `htsget`), allowing all workflow steps to run inside the same container.

**Documentation:**

* Expanded the `README.md` to describe the workflow's purpose, usage, input